### PR TITLE
Settings: display: Fix search indexing of high touch sensitivity

### DIFF
--- a/src/com/android/settings/DisplaySettings.java
+++ b/src/com/android/settings/DisplaySettings.java
@@ -854,7 +854,7 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
                     if (!isCameraGestureAvailable(context.getResources())) {
                         result.add(KEY_CAMERA_GESTURE);
                     }
-                    if (hardware.isSupported(CMHardwareManager.FEATURE_HIGH_TOUCH_SENSITIVITY)) {
+                    if (!hardware.isSupported(CMHardwareManager.FEATURE_HIGH_TOUCH_SENSITIVITY)) {
                         result.add(KEY_HIGH_TOUCH_SENSITIVITY);
                     }
                     return result;


### PR DESCRIPTION
Mark the feature as non-indexable if it is *unsupported*,
not if it is supported.

Change-Id: Ia1388044ec5944e1782f894ed0c6abe4b3e0c9e8